### PR TITLE
Add typescript 2.0 style typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.11",
   "description": "Event monitor for pg-promise.",
   "main": "lib/index.js",
+  "typings": "typescript/pg-monitor.d.ts",
   "scripts": {
     "test": "jasmine-node test",
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "coveralls": "2.x",
     "istanbul": "0.4",
-    "jasmine-node": "1.x"
+    "jasmine-node": "1.x",
+    "typescript": "2.0.x"
   }
 }

--- a/test/typescript/basic.ts
+++ b/test/typescript/basic.ts
@@ -1,6 +1,4 @@
-/// <reference path="../../typescript/pg-monitor" />
-
-import * as pgMonitor from "pg-monitor";
+import { pgMonitor } from "../../typescript/pg-monitor";
 
 var options = {};
 

--- a/typescript/pg-monitor.d.ts
+++ b/typescript/pg-monitor.d.ts
@@ -2,58 +2,53 @@
 // Requires pg-monitor v0.5.8 or later.
 ////////////////////////////////////////
 
-declare module "pg-monitor" {
+interface IColorTheme {
+    time:Function;
+    value:Function;
+    cn:Function;
+    tx:Function;
+    paramTitle:Function;
+    errorTitle:Function;
+    query:Function;
+    special:Function;
+    error:Function;
+}
 
-    interface IColorTheme {
-        time:Function;
-        value:Function;
-        cn:Function;
-        tx:Function;
-        paramTitle:Function;
-        errorTitle:Function;
-        query:Function;
-        special:Function;
-        error:Function;
-    }
+interface IEventInfo {
+    time:Date;
+    text:string;
+    event:string;
+    display:boolean;
+}
 
-    interface IEventInfo {
-        time:Date;
-        text:string;
-        event:string;
-        display:boolean;
-    }
+export module pgMonitor {
 
-    namespace pgMonitor {
+    export function attach(options:Object, events?:Array<string>, override?:boolean):void;
 
-        export function attach(options:Object, events?:Array<string>, override?:boolean):void;
+    export function attach(options:{
+        options:Object,
+        events?:Array<string>,
+        override?:boolean
+    }):void;
 
-        export function attach(options:{
-            options:Object,
-            events?:Array<string>,
-            override?:boolean
-        }):void;
+    export function detach():void;
 
-        export function detach():void;
+    export function setTheme(theme:string|IColorTheme):void;
 
-        export function setTheme(theme:string|IColorTheme):void;
+    export function log(msg:string, info:IEventInfo):void;
 
-        export function log(msg:string, info:IEventInfo):void;
+    export var detailed:boolean;
 
-        export var detailed:boolean;
+    export function connect(client:Object, dc:any, fresh:boolean, detailed?:boolean):void;
 
-        export function connect(client:Object, dc:any, fresh:boolean, detailed?:boolean):void;
+    export function disconnect(client:Object, dc:any, detailed?:boolean):void;
 
-        export function disconnect(client:Object, dc:any, detailed?:boolean):void;
+    export function query(e:Object, detailed?:boolean):void;
 
-        export function query(e:Object, detailed?:boolean):void;
+    export function task(e:Object):void;
 
-        export function task(e:Object):void;
+    export function transact(e:Object):void;
 
-        export function transact(e:Object):void;
+    export function error(err:any, e:Object, detailed?:boolean):void;
 
-        export function error(err:any, e:Object, detailed?:boolean):void;
-
-    }
-
-    export = pgMonitor;
 }


### PR DESCRIPTION
Similar to the PR's for [spex](https://github.com/vitaly-t/spex/pull/6/) and [pg-promise](https://github.com/vitaly-t/pg-promise/pull/238), I also need pg-monitor to include its typings via package.json.


Please let me know if there are any suggested changes.