### PR TITLE
Remove statement saying it works with any version of pg-promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In addition, it simplifies [events logging](#log) for your application.
 $ npm install pg-monitor
 ```
 
-The library has no direct dependency on [pg-promise], and will work with any of its versions.
+The library has no direct dependency on [pg-promise].
 
 # Testing
 


### PR DESCRIPTION
The statement that pg-monitor will work with any version of pg-promise isn't correct and may be confusing. During my testing I had to upgrade pg-promise from 10.9.1 to 11.5.4 to make this work correctly.